### PR TITLE
Feature/set initial diameter

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/mrx_custom/rrt/InformedBiTRRT.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/mrx_custom/rrt/InformedBiTRRT.h
@@ -214,6 +214,16 @@ public:
     }
   }
 
+  void setInitialDiameterMultiplier(double multiplier)
+  {
+    initial_diameter_multiplier_ = multiplier;
+  }
+
+  double getInitialDiameterMultiplier() const
+  {
+    return initial_diameter_multiplier_;
+  }
+
   /// \brief Set a different nearest neighbors datastructure
   void setNearestNeighbors()
   {
@@ -361,6 +371,7 @@ protected:
 
   std::size_t num_solutions_;
   bool cforest_add_path_{ true };
+  double initial_diameter_multiplier_{ 0.0 };
 
   enum OptimalPathRule
   {

--- a/moveit_planners/ompl/ompl_interface/src/mrx_custom/parameterization/joint_pose_model_space.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/mrx_custom/parameterization/joint_pose_model_space.cpp
@@ -117,7 +117,11 @@ void ompl_interface::EllipsoidalSampler::sampleUniform(ompl::base::State* state)
   rng_.uniformProlateHyperspheroid(phs_ptr_, &informedVector[0]);
 
   // Update positions
-  space_->copyPositionsFromReals(state, informedVector);
+  const bool updated = space_->copyPositionsFromReals(state, informedVector);
+
+  // If fail, sample from base sampler
+  if (!updated)
+    base_sampler_->sampleUniform(state);
 }
 
 double ompl_interface::EllipsoidalSampler::getPathLength(ompl::base::State* state) const

--- a/moveit_planners/ompl/ompl_interface/src/mrx_custom/rrt/InformedBiTRRT.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/mrx_custom/rrt/InformedBiTRRT.cpp
@@ -274,16 +274,12 @@ ompl::geometric::InformedBiTRRT::extendTree(Motion* nearest, TreeData& tree, Mot
   // si_->checkMotion assumes that the first argument is valid, so we must check this explicitly
   // If the motion is valid, check the probabilistic transition test and the
   // expansion control to ensure high quality nodes are added.
-  const bool validMotionOnly =
+  bool validMotion =
       (tree == tStart_ ? si_->checkMotion(nearest->state, toMotion->state) :
-                         si_->isValid(toMotion->state) && si_->checkMotion(toMotion->state, nearest->state));
-  const bool transition = transitionTest(tree == tStart_ ? opt_->motionCost(nearest->state, toMotion->state) :
-                                                           opt_->motionCost(toMotion->state, nearest->state));
-  const bool expansion = minExpansionControl(d);
-  bool validMotion = validMotionOnly && transition && expansion;
-
-  if (validMotionOnly && !validMotion)
-    OMPL_WARN("motion check is valid but not valid [%d, %d].", transition, expansion);
+                         si_->isValid(toMotion->state) && si_->checkMotion(toMotion->state, nearest->state)) &&
+      transitionTest(tree == tStart_ ? opt_->motionCost(nearest->state, toMotion->state) :
+                                       opt_->motionCost(toMotion->state, nearest->state)) &&
+      minExpansionControl(d);
 
   if (validMotion)
   {


### PR DESCRIPTION
### Description
 - Add initial diameter option
 - After this PR, Station310 is solved with the following parameters around 1300 secs.

```
  InformedBiTRRT:
    type: geometric::InformedBiTRRT
    range: 0.1  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
    temp_change_factor: 0.1  # how much to increase or decrease temp. default: 0.1
    init_temperature: 100  # initial temperature. default: 100
    frontier_threshold: 0.01  # dist new state to nearest neighbor to disqualify as frontier. default: 0.0 set in setup()
    frontier_node_ratio: 0.1  # 1/10, or 1 nonfrontier for every 10 frontier. default: 0.1
    cost_threshold: 1e300  # the cost threshold. Any motion cost that is not better will not be expanded. default: inf
    optimization_objective: PathLengthOptimizationObjective
    cforest_add_path: 1
    cforest_optimal_path_rule: cost
    initial_diameter_multiplier: 1.414 # sqrt(2)
arm0:
  default_planner_config: InformedBiTRRT
  longest_valid_segment_fraction: 0.0005
```
